### PR TITLE
fixing change pin functionality from returning 500s

### DIFF
--- a/serv.py
+++ b/serv.py
@@ -334,7 +334,7 @@ def changePass():
 @app.route("/changePin",methods=['POST'])
 def changePin():
     remote_ip = request.remote_addr
-    required = ["accountNum","session","newPin"]
+    required = ["accountNum","session","pin","newPin"]
     # Check if we got our required param (for nonwhite-we also need passwordOld)
     for param in required:
         if param in request.form.keys():
@@ -611,4 +611,4 @@ def transferMoney():
  
 
 if __name__ == "__main__":
-	app.run(host='172.30.0.251')
+	app.run(host='10.0.1.10')


### PR DESCRIPTION
when pin parameter is not specified (and was not required), server responds with 500s. see tcp stream:

POST /changePin HTTP/1.1
Host: 10.0.1.10:5000
Accept: _/_
Content-Length: 243
Content-Type: application/x-www-form-urlencoded

accountNum=0112345679&session=%26%23K%3C%3DyAsi%5D%26jT%5D%7D9V2L4%2CW2%5B%40%7Dnh%22wutJQt%409Z%403%3Dp%21CU%60%25ULW-%27cqrCbAnGbR0nCDfISD%5EY%7B5Lr%3BMP%7DYWg-VkkKty%24%2B.dj3fnNj%2C1%247m%3F%3E7z%3Cuz%23Q%3B%7C%7Cwl_oAIPry%2A.&newPin=1299

HTTP/1.0 500 INTERNAL SERVER ERROR
Content-Type: text/html
Content-Length: 291
Server: Werkzeug/0.11.4 Python/2.7.5
Date: Wed, 02 Mar 2016 10:48:05 GMT

<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<title>500 Internal Server Error</title>

<h1>Internal Server Error</h1>

<p>The server encountered an internal error and was unable to complete your request.  Either the server is overloaded or there is an error in the application.</p>
